### PR TITLE
Add patient history creation

### DIFF
--- a/backend/controllers/historial_medicoController.js
+++ b/backend/controllers/historial_medicoController.js
@@ -17,6 +17,14 @@ const getHistorialById = (req, res, next) => {
   });
 };
 
+//obtiene historial medico de un paciente
+const getHistorialByPaciente = (req, res, next) => {
+  Historial.getByPaciente(req.params.id, (err, data) => {
+    if (err) return next(new Error('Error al obtener historial del paciente'));
+    res.json(data);
+  });
+};
+
 //crea un nuevo historial medico
 const createHistorial = (req, res, next) => {
   Historial.create(req.body, (err, result) => {
@@ -46,6 +54,7 @@ const deleteHistorial = (req, res, next) => {
 module.exports = {
   getHistoriales,
   getHistorialById,
+  getHistorialByPaciente,
   createHistorial,
   updateHistorial,
   deleteHistorial

--- a/backend/models/historial_medicoModel.js
+++ b/backend/models/historial_medicoModel.js
@@ -8,6 +8,9 @@ const HistorialMedico = {
   getById: (id, callback) => {
     db.query('SELECT * FROM historial_medico WHERE id_historial = ?', [id], callback);
   },
+  getByPaciente: (idPaciente, callback) => {
+    db.query('SELECT * FROM historial_medico WHERE id_paciente = ?', [idPaciente], callback);
+  },
   create: (historial, callback) => {
     db.query('INSERT INTO historial_medico SET ?', historial, callback);
   },

--- a/backend/routes/historial_medicoRoutes.js
+++ b/backend/routes/historial_medicoRoutes.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const router = express.Router();
-const controller = require('../controllers/historial_MedicoController');
+const controller = require('../controllers/historial_medicoController');
 
 //define rutas para funciones de obtener, crear, actualizar y eliminar
 router.get('/', controller.getHistoriales);
+router.get('/paciente/:id', controller.getHistorialByPaciente);
 router.get('/:id', controller.getHistorialById);
 router.post('/', controller.createHistorial);
 router.put('/:id', controller.updateHistorial);    

--- a/backend/routes/paciente_tratamientoRoutes.js
+++ b/backend/routes/paciente_tratamientoRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const controller = require('../controllers/paciente_TratamientoController');
+const controller = require('../controllers/paciente_tratamientoController');
 
 //define rutas para funciones de obtener, crear, actualizar y eliminar
 router.get('/', controller.getPacienteTratamientos);

--- a/frontend/src/app/historial-medico/historial-paciente/historial-paciente.component.html
+++ b/frontend/src/app/historial-medico/historial-paciente/historial-paciente.component.html
@@ -19,4 +19,12 @@
       </div>
     </div>
   </div>
+
+  <form (ngSubmit)="agregarHistorial()" class="mt-4">
+    <div class="mb-3">
+      <label for="nuevoHistorial" class="form-label fw-bold">Nuevo Registro</label>
+      <textarea id="nuevoHistorial" class="form-control" [(ngModel)]="nuevoHistorial" name="nuevoHistorial" rows="3"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Agregar Historial</button>
+  </form>
 </div>

--- a/frontend/src/app/historial-medico/historial-paciente/historial-paciente.component.ts
+++ b/frontend/src/app/historial-medico/historial-paciente/historial-paciente.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { NavBarComponent } from "../../estatico/nav-bar/nav-bar.component";
 import { FooterComponent } from "../../estatico/footer/footer.component";
 import { HistorialMedicoService, HistorialMedico } from '../../servicios/historial.service';
@@ -8,13 +9,14 @@ import { HistorialMedicoService, HistorialMedico } from '../../servicios/histori
 @Component({
   selector: 'app-historial-paciente',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './historial-paciente.component.html',
   styleUrls: ['./historial-paciente.component.css']
 })
 export class HistorialPacienteComponent implements OnInit {
   idPaciente!: number;
   historial: HistorialMedico[] = [];
+  nuevoHistorial = '';
 
   constructor(
     private route: ActivatedRoute,
@@ -32,6 +34,23 @@ export class HistorialPacienteComponent implements OnInit {
     this.historialService.getByPaciente(this.idPaciente).subscribe({
       next: (data) => this.historial = data,
       error: (err) => console.error('Error al cargar historial médico', err)
+    });
+  }
+
+  agregarHistorial(): void {
+    if (!this.nuevoHistorial.trim()) return;
+
+    const datos: HistorialMedico = {
+      descripcion: this.nuevoHistorial,
+      id_paciente: String(this.idPaciente)
+    };
+
+    this.historialService.create(datos).subscribe({
+      next: () => {
+        this.nuevoHistorial = '';
+        this.cargarHistorial();
+      },
+      error: err => console.error('Error al crear historial', err)
     });
   }
 }


### PR DESCRIPTION
## Summary
- fix controller path for patient treatments
- implement route and controller to fetch patient history
- add model function for histories by patient
- expose history retrieval route before ID route
- embed history creation form in patient view

## Testing
- `npm test` in backend *(fails: Error: no test specified)*
- `npm test` in frontend *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab4521fac8332b50eaaeb8fb80d33