### PR TITLE
Fix date handling for patient form

### DIFF
--- a/frontend/src/app/servicios/paciente.service.ts
+++ b/frontend/src/app/servicios/paciente.service.ts
@@ -4,10 +4,15 @@ import { Observable } from 'rxjs';
 
 //define la interfaz Paciente con sus propiedades
 export interface Paciente {
-  id_paciente: string;
+  id_paciente?: string;
   nombre: string;
   apellido: string;
-  fecha_nacimiento?: string;
+  /**
+   * Fecha de nacimiento manejada como string en el frontend pero almacenada
+   * como `DATE` en la base de datos.  Se acepta `string` o `Date` para
+   * simplificar la conversión antes de enviar los datos al backend.
+   */
+  fecha_nacimiento?: string | Date;
   telefono?: string;
   email?: string;
   direccion?: string;
@@ -32,11 +37,23 @@ export class PacienteService {
   }
 
   create(paciente: Paciente): Observable<Paciente> {
-    return this.http.post<Paciente>(this.apiUrl, paciente);
+    const payload = {
+      ...paciente,
+      fecha_nacimiento: paciente.fecha_nacimiento
+        ? new Date(paciente.fecha_nacimiento)
+        : undefined,
+    };
+    return this.http.post<Paciente>(this.apiUrl, payload);
   }
 
   update(id: string, paciente: Paciente): Observable<any> {
-    return this.http.put(`${this.apiUrl}/${id}`, paciente);
+    const payload = {
+      ...paciente,
+      fecha_nacimiento: paciente.fecha_nacimiento
+        ? new Date(paciente.fecha_nacimiento)
+        : undefined,
+    };
+    return this.http.put(`${this.apiUrl}/${id}`, payload);
   }
 
   delete(id: string): Observable<any> {


### PR DESCRIPTION
## Summary
- allow `id_paciente` to be optional in `Paciente` interface
- document that `fecha_nacimiento` can be `string | Date`
- convert `fecha_nacimiento` to a `Date` object when creating or updating a patient

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b45c8a3b0833286dedce4d2087cec