### PR TITLE
Improve DB config flexibility

### DIFF
--- a/frontend/node-express-mysql-rest-api/index.js
+++ b/frontend/node-express-mysql-rest-api/index.js
@@ -10,10 +10,10 @@ const port = 3000;
 
 // Conexión a la base de datos
 const db = mysql.createConnection({
-  host: 'localhost',
-  user: 'root',
-  password: '',
-  database: 'clinicadb'
+  host: process.env.MYSQL_HOST || 'localhost',
+  user: process.env.MYSQL_USER || 'root',
+  password: process.env.MYSQL_PASSWORD || '',
+  database: process.env.MYSQL_DATABASE || 'clinicadb'
 });
 
 db.connect(err => {


### PR DESCRIPTION
## Summary
- allow Node API to read MySQL credentials from environment variables

## Testing
- `npm test` *(fails: ng not found)*
- `npx tsc -p frontend/tsconfig.json --pretty false` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d8f5bd1788332924acf36734ec620